### PR TITLE
Allow Certificate names that aren't DNS-1035 labels.

### DIFF
--- a/pkg/reconciler/certificate/certificate.go
+++ b/pkg/reconciler/certificate/certificate.go
@@ -127,7 +127,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.Certificate)
 }
 
 func (r *Reconciler) reconcileService(ctx context.Context, o *v1alpha1.Certificate) (*corev1.Service, error) {
-	svc, err := r.serviceLister.Services(o.Namespace).Get(o.Name)
+	svc, err := r.serviceLister.Services(o.Namespace).Get(resources.ServiceName(o))
 	if apierrs.IsNotFound(err) {
 		svc = resources.MakeService(o, resources.WithServicePort(r.challengePort))
 		if _, err := r.kubeClient.CoreV1().Services(o.Namespace).Create(ctx, svc, metav1.CreateOptions{}); err != nil {
@@ -150,7 +150,7 @@ func (r *Reconciler) reconcileService(ctx context.Context, o *v1alpha1.Certifica
 }
 
 func (r *Reconciler) reconcileEndpoints(ctx context.Context, o *v1alpha1.Certificate) error {
-	if ep, err := r.endpointsLister.Endpoints(o.Namespace).Get(o.Name); apierrs.IsNotFound(err) {
+	if ep, err := r.endpointsLister.Endpoints(o.Namespace).Get(resources.ServiceName(o)); apierrs.IsNotFound(err) {
 		ep = resources.MakeEndpoints(o, resources.WithEndpointsPort(r.challengePort))
 		if _, err := r.kubeClient.CoreV1().Endpoints(o.Namespace).Create(ctx, ep, metav1.CreateOptions{}); err != nil {
 			return err

--- a/pkg/reconciler/certificate/resources/service.go
+++ b/pkg/reconciler/certificate/resources/service.go
@@ -40,7 +40,7 @@ func ServiceName(cert *v1alpha1.Certificate) string {
 	//
 	// UUID are 35 chars long so we are under the 63 chars limit here,
 	// but we can use kmeta.ChildName here to be future-proof.
-	return kmeta.ChildName("challenge-for-"+string(cert.GetUID()), "")
+	return kmeta.ChildName("challenge-for-", string(cert.GetUID()))
 }
 
 // MakeService creates a Service, which we will point at ourselves.

--- a/pkg/reconciler/certificate/resources/service.go
+++ b/pkg/reconciler/certificate/resources/service.go
@@ -37,7 +37,10 @@ func ServiceName(cert *v1alpha1.Certificate) string {
 		return name
 	}
 	// Fall back to a less readable name but guaranteed to be DNS-1035 label.
-	return "challenge-for-" + string(cert.GetUID())
+	//
+	// UUID are 35 chars long so we are under the 63 chars limit here,
+	// but we can use kmeta.ChildName here to be future-proof.
+	return kmeta.ChildName("challenge-for-"+string(cert.GetUID()), "")
 }
 
 // MakeService creates a Service, which we will point at ourselves.

--- a/pkg/reconciler/certificate/resources/service.go
+++ b/pkg/reconciler/certificate/resources/service.go
@@ -30,7 +30,7 @@ import (
 
 const portName = "http-challenge"
 
-func svcName(cert *v1alpha1.Certificate) string {
+func ServiceName(cert *v1alpha1.Certificate) string {
 	// Service names must be a DNS-1035 label. We try to use the
 	// Certificate name first if possible.
 	if name := kmeta.ChildName(cert.Name, ""); 0 == len(validation.IsDNS1035Label(name)) {
@@ -47,7 +47,7 @@ func svcName(cert *v1alpha1.Certificate) string {
 func MakeService(o *v1alpha1.Certificate, opts ...func(*corev1.Service)) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            svcName(o),
+			Name:            ServiceName(o),
 			Namespace:       o.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(o)},
 		},
@@ -71,7 +71,7 @@ func MakeService(o *v1alpha1.Certificate, opts ...func(*corev1.Service)) *corev1
 func MakeEndpoints(o *v1alpha1.Certificate, opts ...func(*corev1.Endpoints)) *corev1.Endpoints {
 	ep := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            svcName(o),
+			Name:            ServiceName(o),
 			Namespace:       o.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(o)},
 		},

--- a/pkg/reconciler/certificate/resources/service_test.go
+++ b/pkg/reconciler/certificate/resources/service_test.go
@@ -125,18 +125,19 @@ func TestMakeService(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo.com",
 				Namespace: "bar",
-				UID:       "42-42-1234",
+				// UUID should be 35 chars long
+				UID: "123e4567-e89b-12d3-a456-426614174000",
 			},
 		},
 		want: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "challenge-for-42-42-1234",
+				Name:      "challenge-for-123e4567-e89b-12d3-a456-426614174000",
 				Namespace: "bar",
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
 					Kind:               "Certificate",
 					Name:               "foo.com",
-					UID:                "42-42-1234",
+					UID:                "123e4567-e89b-12d3-a456-426614174000",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},

--- a/pkg/reconciler/certificate/resources/service_test.go
+++ b/pkg/reconciler/certificate/resources/service_test.go
@@ -119,6 +119,36 @@ func TestMakeService(t *testing.T) {
 			},
 		},
 		opts: []func(*corev1.Service){WithServicePort(1234)},
+	}, {
+		name: "name has dots",
+		o: &v1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo.com",
+				Namespace: "bar",
+				UID:       "42-42-1234",
+			},
+		},
+		want: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "challenge-for-42-42-1234",
+				Namespace: "bar",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Certificate",
+					Name:               "foo.com",
+					UID:                "42-42-1234",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name:       portName,
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+				}},
+			},
+		},
 	}}
 
 	for _, test := range tests {
@@ -231,6 +261,39 @@ func TestMakeEndpoints(t *testing.T) {
 			}},
 		},
 		opts: []func(*corev1.Endpoints){WithEndpointsPort(1234)},
+	}, {
+		name: "name has dots",
+		o: &v1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar.com",
+				Namespace: "food",
+				UID:       "dead-beef",
+			},
+		},
+		want: &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "challenge-for-dead-beef",
+				Namespace: "food",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Certificate",
+					Name:               "bar.com",
+					UID:                "dead-beef",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{
+					IP: os.Getenv("POD_IP"),
+				}},
+				Ports: []corev1.EndpointPort{{
+					Name:     portName,
+					Port:     8080,
+					Protocol: corev1.ProtocolTCP,
+				}},
+			}},
+		},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Allow Certificate names that aren't DNS-1035 labels. This fix is safe to roll out since previously we couldn't create the child resources (Service, Endpoints) using non DNS1035 anyway.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Make sure we can handle all kind of Certificate names.
```

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
