### PR TITLE
Add k8s recommended labels

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -18,8 +18,8 @@ metadata:
   name: net-http01-controller
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: http01
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-http01
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: http01

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -18,6 +18,9 @@ metadata:
   name: net-http01-controller
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: http01
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: http01
 spec:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,8 +35,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|")
+    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,6 +18,9 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: http01
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 ---
 kind: ClusterRole
@@ -25,6 +28,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
+    app.kubernetes.io/name: http01
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
@@ -37,6 +43,9 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
+    app.kubernetes.io/name: http01
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,8 +18,8 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: http01
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-http01
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 ---
@@ -28,8 +28,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    app.kubernetes.io/name: http01
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-http01
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 aggregationRule:
@@ -43,8 +43,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    app.kubernetes.io/name: http01
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-http01
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 subjects:

--- a/test/config/300-certificate.yaml
+++ b/test/config/300-certificate.yaml
@@ -17,6 +17,9 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
+    app.kubernetes.io/name: http01
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:

--- a/test/config/300-certificate.yaml
+++ b/test/config/300-certificate.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: http01
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-http01
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"


### PR DESCRIPTION
# Changes

Adds Kubernetes recommended labels to networking as discussed in https://github.com/knative/networking/issues/552

Note that changes to the labels in `vendor/knative.dev/networking` should be handled by the automation once https://github.com/knative/networking/pull/555 merges. 

/kind enhancement