### PR TITLE
Add secret label for filtering informers

### DIFF
--- a/pkg/reconciler/certificate/resources/secret.go
+++ b/pkg/reconciler/certificate/resources/secret.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 
@@ -99,6 +100,7 @@ func MakeSecret(o *v1alpha1.Certificate, cert *tls.Certificate) (*corev1.Secret,
 			Name:            o.Spec.SecretName,
 			Namespace:       o.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(o)},
+			Labels:          map[string]string{networking.CertificateUIDLabelKey: string(o.GetUID())},
 		},
 		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{

--- a/pkg/reconciler/certificate/resources/secret_test.go
+++ b/pkg/reconciler/certificate/resources/secret_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/ptr"
 )
@@ -129,6 +130,7 @@ func TestMakeSecret(t *testing.T) {
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
+				Labels: map[string]string{networking.CertificateUIDLabelKey: ""},
 			},
 			Type: corev1.SecretTypeTLS,
 			Data: map[string][]byte{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Part of the work here: https://github.com/knative-sandbox/net-istio/pull/920. Similar to https://github.com/knative-sandbox/net-certmanager/pull/402
- Add a label for secret filtering from secret informers.
- We could use a filtering informer for secrets listed in this component too in case there is a mem issue. 

