### PR TITLE
[release-1.8] Skip HTTP01 conformance test in 1.8 release

### DIFF
--- a/test/conformance/certificate_test.go
+++ b/test/conformance/certificate_test.go
@@ -23,5 +23,6 @@ import (
 )
 
 func TestHTTP01Conformance(t *testing.T) {
+	t.Skip("Skipping http01 conformance test. See issues/424.")
 	http01.RunConformance(t)
 }


### PR DESCRIPTION
As https://github.com/knative-sandbox/net-http01/issues/424, it seems we might hit a Let's encrypt's policy.
This patch skips the test for now to unblock 1.8 release.

/cc @lionelvillard 