### PR TITLE
[wip] use knative.test for http01 testing

### DIFF
--- a/vendor/knative.dev/networking/test/conformance/certificate/http01/certificate.go
+++ b/vendor/knative.dev/networking/test/conformance/certificate/http01/certificate.go
@@ -32,8 +32,8 @@ func TestHTTP01Challenge(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	certDomains := [][]string{
-		{subDomain + ".knative.test"},
-		{subDomain + "2.knative.test", subDomain + "3.knative.test"},
+		{subDomain + ".knative.dev"},
+		{subDomain + "2.knative.dev", subDomain + "3.knative.dev"},
 	}
 
 	for _, domains := range certDomains {

--- a/vendor/knative.dev/networking/test/conformance/certificate/http01/certificate.go
+++ b/vendor/knative.dev/networking/test/conformance/certificate/http01/certificate.go
@@ -32,8 +32,8 @@ func TestHTTP01Challenge(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	certDomains := [][]string{
-		{subDomain + ".example.com"},
-		{subDomain + "2.example.com", subDomain + "3.example.com"},
+		{subDomain + ".knative.test"},
+		{subDomain + "2.knative.test", subDomain + "3.knative.test"},
 	}
 
 	for _, domains := range certDomains {


### PR DESCRIPTION
Seeing if using another domain besides example.com works

related: https://github.com/knative-sandbox/net-http01/issues/424